### PR TITLE
Publish ワークフローの修正

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,8 +55,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v${{ github.ref }}
-          release_name: v${{ github.ref }}
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
           body: |
             ${{ steps.release_note.outputs.release_note }}
           draft: false


### PR DESCRIPTION
タグにvプレフィックスがついているので、リリースのタイトル等に付与することは不要でした。