### PR TITLE
git-checksの無効化

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
           registry-url: https://npm.pkg.github.com/
+          git-checks: false
           always-auth: true
           scope: "@yukonsky"
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 engine-strict=true
 registry=https://npm.pkg.github.com/yukonsky
+git-checks=false


### PR DESCRIPTION
[Workflowが落ちた](https://github.com/yukonsky/reg-publish-azure-blob-storage-plugin/actions/runs/5713128470/job/15477925529)ため、git-checksを無効化します。